### PR TITLE
Update vmseriesPrivateImage.json

### DIFF
--- a/azure/rel_template1.1/hub/vmseriesPrivateImage.json
+++ b/azure/rel_template1.1/hub/vmseriesPrivateImage.json
@@ -262,6 +262,11 @@
                 "tier": "Standard",
                 "capacity": "[parameters('vmScaleSetMinCount')]"
             },
+            "plan": {
+            "name": "[parameters('vmSku')]",
+            "product": "[variables('imageOffer')]",
+            "publisher": "[variables('imagePublisher')]"
+            },
             "properties": {
                 "overprovision": "false",
                 "singlePlacementGroup": "false",


### PR DESCRIPTION
Adding back the plan info based of jira : PLUG-18082- [Azure does not support plan information for custom images anymore unless the custom image is created out of a Marketplace image]

Also starting this bug we would be documenting the only supported way for handling custom image on azure orchestration plugin would be when the custom image itself is created from marketplace image.